### PR TITLE
PATCH: sync docs with current CLI; align schema; fix examples; gate t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ Open Workbench solves the "blank canvas" problem by automating the tedious setup
 
 **In short:** Open Workbench is the fastest way to go from zero to a running, production-grade app—locally or in the cloud.
 
+## Try it in 60 seconds
+```
+# macOS / Linux
+brew install jashkahar/tap/open-workbench-platform
+
+# Windows (PowerShell)
+scoop bucket add jashkahar https://github.com/jashkahar/scoop-bucket.git
+scoop install open-workbench-platform
+
+# If that does not work
+go install github.com/jashkahar/open-workbench-platform@latest
+
+# Quickstart (interactive)
+om init
+om add service --template fastapi-basic
+om compose --target docker
+
+# requires docker desktop installed
+docker compose up --build
+
+# Then open your browser (example)
+# http://localhost:8000
+```
+
 ## 🚀 Quick Start
 
 ### Installation

--- a/cmd/add_service.go
+++ b/cmd/add_service.go
@@ -57,16 +57,16 @@ Interactive Mode (no parameters):
   om add component
 
 Direct Mode (with parameters):
-  om add component --name gateway --template fastapi-basic
+  om add component --name gateway --template nginx-gateway
 
 Examples:
   # Interactive mode - prompts for all details
   om add component
 
   # Direct mode with all parameters
-  om add component --name gateway --template fastapi-basic
+  om add component --name gateway --template nginx-gateway
 
-Available templates: react-typescript, nextjs-full-stack, fastapi-basic, express-api, vue-nuxt`,
+Available templates: react-typescript, nextjs-full-stack, fastapi-basic, express-api, vue-nuxt, nginx-gateway, redis-cache`,
 	RunE: runAddComponent,
 }
 
@@ -608,6 +608,7 @@ func updateWorkbenchManifest(manifest *manifestPkg.WorkbenchManifest, serviceNam
 	manifest.Services[serviceName] = manifestPkg.Service{
 		Template: templateName,
 		Path:     filepath.Join(".", serviceName),
+		Port:     defaultServicePort(templateName),
 	}
 
 	// Marshal to YAML
@@ -624,6 +625,24 @@ func updateWorkbenchManifest(manifest *manifestPkg.WorkbenchManifest, serviceNam
 	}
 
 	return nil
+}
+
+// defaultServicePort returns a sensible external/internal port for well-known templates
+func defaultServicePort(templateName string) int {
+	switch strings.ToLower(templateName) {
+	case "express-api":
+		return 3001
+	case "react-typescript":
+		return 4173
+	case "nextjs-full-stack":
+		return 3002
+	case "fastapi-basic":
+		return 8000
+	case "vue-nuxt":
+		return 3000
+	default:
+		return 0
+	}
 }
 
 // printAddServiceSuccessMessage prints a success message for adding a service
@@ -985,7 +1004,10 @@ func printAddComponentSuccessMessage(componentName, templateName string) {
 	fmt.Println()
 	fmt.Println("🚀 Next steps:")
 	fmt.Printf("  cd %s\n", componentName)
-	fmt.Println("  om add service  # Add services to your project")
+	fmt.Println("  om add service   # Add services to your project")
 	fmt.Println("  om add component # Add more components to your project")
-	fmt.Println("  om compose      # Generate Docker Compose configuration")
+	fmt.Println("  om compose       # Generate Docker Compose configuration")
+	fmt.Println()
+	fmt.Println("ℹ️ Edit your component config:")
+	fmt.Printf("  - Path: ./%s (e.g., update nginx config, set ports in workbench.yaml)\n", componentName)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -534,6 +534,7 @@ func createWorkbenchManifest(projectName, serviceName, templateName string) erro
 			serviceName: {
 				Template: templateName,
 				Path:     filepath.Join(".", serviceName),
+				Port:     defaultServicePort(templateName),
 			},
 		},
 	}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -214,5 +214,4 @@ func printSummary(manifest *manifestPkg.WorkbenchManifest) {
 	fmt.Println()
 	fmt.Println("💡 Use 'om ls --detailed' for more information")
 	fmt.Println("💡 Use 'om compose --target docker' to generate local configuration")
-	fmt.Println("💡 Use 'om compose --target terraform' to generate cloud configuration")
 }

--- a/docs/CREATING_A_TEMPLATE.md
+++ b/docs/CREATING_A_TEMPLATE.md
@@ -55,7 +55,7 @@ The `template.json` file defines the template's behavior and parameters.
       "name": "ParameterName",
       "prompt": "User prompt text",
       "group": "Parameter Group",
-      "type": "string|boolean|select|multi-select",
+      "type": "string|boolean|select|multiselect",
       "required": true,
       "default": "default_value",
       "validation": {
@@ -126,13 +126,13 @@ The `template.json` file defines the template's behavior and parameters.
 }
 ```
 
-#### Multi-Select Parameters
+#### Multiselect Parameters
 
 ```json
 {
   "name": "Features",
   "prompt": "Select features:",
-  "type": "multi-select",
+  "type": "multiselect",
   "options": ["Authentication", "Database", "API", "Testing"]
 }
 ```
@@ -253,8 +253,8 @@ Files can be conditionally included by using empty names:
 The `workbench.yaml` file is automatically generated and updated by the system:
 
 ```yaml
-apiVersion: v1
-kind: Workbench
+apiVersion: openworkbench.io/v1alpha1
+kind: Project
 metadata:
   name: project-name
 environments:
@@ -264,13 +264,13 @@ environments:
 services:
   frontend:
     template: nextjs-full-stack
-    path: frontend
+    path: ./frontend
     port: 3000
     environment:
       NODE_ENV: development
   backend:
     template: fastapi-basic
-    path: backend
+    path: ./backend
     port: 8000
     resources:
       database:
@@ -279,7 +279,7 @@ services:
 components:
   gateway:
     template: nginx-gateway
-    path: gateway
+    path: ./gateway
     ports: ["80", "443"]
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,7 +82,7 @@ The templating engine is the core of the system, providing dynamic template proc
 - Provides progress reporting
 
 **Parameter System** (`parameters.go`):
-- Defines parameter types (string, boolean, select, multi-select)
+- Defines parameter types (string, boolean, select, multiselect)
 - Handles parameter validation and grouping
 - Manages interactive prompting
 
@@ -144,10 +144,7 @@ The generator system creates deployment configurations from the manifest.
 - Supports volume mounts
 
 #### Terraform Generator (`generator/terraform/`)
-- Generates Terraform configurations
-- Supports multiple cloud providers
-- Handles environment-specific configurations
-- Manages infrastructure as code
+- (Temporarily disabled) Future support for generating Terraform configurations
 
 ### Security Layer (`cmd/security.go`)
 
@@ -210,15 +207,19 @@ Generate deployment configuration.
 List project services and components.
 
 **Flags:**
-- None
+- `--detailed`: Show detailed information including paths, ports, env vars, and resource configs
 
 ### `om delete`
 
-Remove services or components.
+Remove services, components, or resources.
 
-**Flags:**
-- `--name`: Name of service/component to delete
-- `--type`: Type (service or component)
+Subcommands and flags:
+- `om delete service [name]` — remove a service from `workbench.yaml`
+  - Flags: `--files` (also delete the service directory and files)
+- `om delete component [name]` — remove a component from `workbench.yaml`
+  - Flags: `--files` (also delete the component directory and files)
+- `om delete resource service.resource` — remove a resource from a service
+  - Example: `om delete resource backend.database`
 
 ## Security Architecture
 

--- a/internal/compose/types.go
+++ b/internal/compose/types.go
@@ -57,7 +57,7 @@ type BuildConfig struct {
 
 // DockerComposeConfig represents the complete docker-compose.yml structure
 type DockerComposeConfig struct {
-	Version  string                          `yaml:"version"`
+	Version  string                          `yaml:"version,omitempty"`
 	Services map[string]DockerComposeService `yaml:"services"`
 	Volumes  map[string]interface{}          `yaml:"volumes,omitempty"`
 	Networks map[string]interface{}          `yaml:"networks,omitempty"`

--- a/internal/resources/registry.go
+++ b/internal/resources/registry.go
@@ -235,36 +235,6 @@ func (r *Registry) registerDefaultBlueprints() {
 		},
 	}
 
-	// Storage resources
-	r.blueprints["s3-bucket"] = ResourceBlueprint{
-		Name:        "s3-bucket",
-		Description: "An AWS S3 Bucket",
-		Category:    "storage",
-		DockerComposeSnippet: `
-    image: minio/minio:{{.Version}}
-    command: server /data --console-address ":9001"
-    environment:
-      - MINIO_ROOT_USER={{.AccessKey}}
-      - MINIO_ROOT_PASSWORD={{.SecretKey}}
-    volumes:
-      - minio_data:/data
-    ports:
-      - "{{.Port}}:9000"
-      - "9001:9001"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 5`,
-		TerraformModule: "modules/aws/s3",
-		Parameters: []ResourceParameter{
-			{Name: "version", Description: "MinIO version", Type: "select", Required: true, Default: "latest", Options: []string{"latest", "RELEASE.2023-10-07T15-07-38Z"}},
-			{Name: "accessKey", Description: "Access key", Type: "string", Required: true, Default: "minioadmin"},
-			{Name: "secretKey", Description: "Secret key", Type: "string", Required: true},
-			{Name: "port", Description: "MinIO port", Type: "number", Required: false, Default: 9000},
-		},
-	}
-
 	// Message queue resources
 	r.blueprints["rabbitmq"] = ResourceBlueprint{
 		Name:        "rabbitmq",
@@ -291,47 +261,6 @@ func (r *Registry) registerDefaultBlueprints() {
 			{Name: "username", Description: "RabbitMQ username", Type: "string", Required: true, Default: "admin"},
 			{Name: "password", Description: "RabbitMQ password", Type: "string", Required: true},
 			{Name: "port", Description: "RabbitMQ port", Type: "number", Required: false, Default: 5672},
-		},
-	}
-
-	r.blueprints["kafka"] = ResourceBlueprint{
-		Name:        "kafka",
-		Description: "An Apache Kafka Message Queue",
-		Category:    "message-queue",
-		DockerComposeSnippet: `
-    image: confluentinc/cp-kafka:{{.Version}}
-    environment:
-      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,PLAINTEXT_HOST://:29092
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_CFG_PROCESS_ROLES: broker
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:29093,PLAINTEXT_HOST://:29092
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_CFG_PROCESS_ROLES: broker
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:29093,PLAINTEXT_HOST://:29092
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_CFG_PROCESS_ROLES: broker
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-    ports:
-      - "{{.Port}}:9092"
-      - "29092:29092"
-    depends_on:
-      - zookeeper`,
-		TerraformModule: "modules/aws/msk",
-		Parameters: []ResourceParameter{
-			{Name: "version", Description: "Kafka version", Type: "select", Required: true, Default: "7.4.0", Options: []string{"7.4.0", "7.3.0"}},
-			{Name: "port", Description: "Kafka port", Type: "number", Required: false, Default: 9092},
 		},
 	}
 }

--- a/templates/express-api/Dockerfile
+++ b/templates/express-api/Dockerfile
@@ -1,23 +1,29 @@
-# Use Node.js 18 Alpine as base image
-FROM node:18-alpine
+###### Local/dev-friendly multi-stage build to ensure TypeScript compilation and native deps reliability
 
-# Set working directory
+# Stage 1: build with devDependencies
+FROM node:18-bullseye-slim AS builder
 WORKDIR /app
-
-# Copy package files
 COPY package*.json ./
-
-# Install dependencies
-RUN npm ci --only=production
-
-# Copy application code
+RUN sh -lc 'if [ -f package-lock.json ]; then npm ci; else npm install; fi'
 COPY . .
+RUN npm run build
 
-# Build the application (if there's a build script)
-RUN npm run build || true
+# Stage 2: production runtime with only prod deps
+FROM node:18-bullseye-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=development \
+    # Defaults for local Docker Desktop to reach host DBs
+    DB_HOST=host.docker.internal \
+    MONGO_URI=mongodb://host.docker.internal:27017/express_api \
+    PORT=3001
 
-# Expose port
-EXPOSE 3000
+COPY package*.json ./
+RUN sh -lc 'if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi'
 
-# Start the application
-CMD ["npm", "start"] 
+# Copy compiled app
+COPY --from=builder /app/dist ./dist
+
+# Expose API port (unique for local/dev)
+EXPOSE 3001
+
+CMD ["node", "dist/index.js"]

--- a/templates/express-api/env.example
+++ b/templates/express-api/env.example
@@ -1,5 +1,5 @@
 # Server Configuration
-PORT=3000
+PORT=3001
 NODE_ENV=development
 
 # JWT Configuration

--- a/templates/express-api/src/database/mongo/index.ts
+++ b/templates/express-api/src/database/mongo/index.ts
@@ -2,7 +2,9 @@ import mongoose from 'mongoose';
 
 const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/express_api');
+    const conn = await mongoose.connect(
+      process.env.MONGO_URI || 'mongodb://host.docker.internal:27017/express_api'
+    );
     console.log(`MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {
     console.error('Error connecting to MongoDB:', error);

--- a/templates/express-api/src/database/postgres/index.ts
+++ b/templates/express-api/src/database/postgres/index.ts
@@ -2,7 +2,7 @@ import { Pool } from 'pg';
 
 const pool = new Pool({
   user: process.env.DB_USER || 'postgres',
-  host: process.env.DB_HOST || 'localhost',
+  host: process.env.DB_HOST || 'host.docker.internal',
   database: process.env.DB_NAME || 'express_api',
   password: process.env.DB_PASSWORD || 'password',
   port: parseInt(process.env.DB_PORT || '5432'),

--- a/templates/express-api/template.json
+++ b/templates/express-api/template.json
@@ -105,7 +105,7 @@
         "condition": "InstallDeps == true"
       },
       {
-        "command": "copy env.example .env 2>nul || cp env.example .env 2>/dev/null || echo 'env.example not found, skipping .env creation'",
+        "command": "node -e \"try{require('fs').copyFileSync('env.example','.env');console.log('Created .env from env.example')}catch(e){console.log('env.example not found, skipping .env creation')}\"",
         "description": "Creating environment file...",
         "condition": "true"
       },

--- a/templates/express-api/tsconfig.json
+++ b/templates/express-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+
+

--- a/templates/fastapi-basic/template.json
+++ b/templates/fastapi-basic/template.json
@@ -86,9 +86,14 @@
         "condition": "IncludeVirtualEnv == true"
       },
       {
+        "command": "python -c \"import platform,subprocess; py='venv\\\\Scripts\\\\python.exe' if platform.system()=='Windows' else 'venv/bin/python'; subprocess.check_call([py,'-m','pip','install','-r','requirements.txt'])\"",
+        "description": "Installing Python dependencies into the created virtual environment...",
+        "condition": "InstallDeps == true && IncludeVirtualEnv == true"
+      },
+      {
         "command": "pip install -r requirements.txt",
-        "description": "Installing Python dependencies...",
-        "condition": "InstallDeps == true"
+        "description": "Installing Python dependencies (no virtual environment)...",
+        "condition": "InstallDeps == true && IncludeVirtualEnv == false"
       }
     ]
   }

--- a/templates/nextjs-full-stack/Dockerfile
+++ b/templates/nextjs-full-stack/Dockerfile
@@ -12,5 +12,7 @@ WORKDIR /app
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
-EXPOSE 3000
-CMD ["npm", "start"] 
+ENV NODE_ENV=development \
+    PORT=3002
+EXPOSE 3002
+CMD ["sh", "-lc", "PORT=$PORT npm start"]

--- a/templates/nextjs-full-stack/src/app/layout.tsx
+++ b/templates/nextjs-full-stack/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next'
+import React from 'react'
+
+export const metadata: Metadata = {
+  title: '{{.ProjectName}}',
+  description: 'Scaffolded by Open Workbench CLI',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}
+
+

--- a/templates/nextjs-full-stack/tsconfig.json
+++ b/templates/nextjs-full-stack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "esnext"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", ".next", "dist"]
+}
+
+

--- a/templates/nginx-gateway/Dockerfile
+++ b/templates/nginx-gateway/Dockerfile
@@ -1,16 +1,19 @@
 FROM nginx:alpine
 
+# Install curl for healthcheck in local/dev
+RUN apk add --no-cache curl
+
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
 
 # Copy default site configuration
 COPY default.conf /etc/nginx/conf.d/default.conf
 
-# Expose port
-EXPOSE {{.Port}}
+# Expose default HTTP port (informational)
+EXPOSE 80
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost/health || exit 1
 
-CMD ["nginx", "-g", "daemon off;"] 
+CMD ["nginx", "-g", "daemon off;"]

--- a/templates/react-typescript/Dockerfile
+++ b/templates/react-typescript/Dockerfile
@@ -1,23 +1,18 @@
-# Use the official Node.js runtime as the base image
 FROM node:18-alpine
 
-# Set the working directory in the container
 WORKDIR /app
 
-# Copy package.json and package-lock.json (if available)
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Install full deps to build; fall back if no lockfile
+RUN sh -lc 'if [ -f package-lock.json ]; then npm ci; else npm install; fi'
 
-# Copy the rest of the application code
 COPY . .
 
-# Build the application
 RUN npm run build
 
-# Expose the port the app runs on
-EXPOSE 3000
+# Vite preview default port (overridable)
+EXPOSE 4173
 
-# Start the application
-CMD ["npm", "start"] 
+# Local/dev-friendly start
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "4173"]

--- a/templates/react-typescript/index.html
+++ b/templates/react-typescript/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{.ProjectName}}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+  </html>
+
+

--- a/templates/react-typescript/package.json
+++ b/templates/react-typescript/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"{{if .IncludeTesting}},
+    "preview": "vite preview",
+    "start": "vite preview --host 0.0.0.0 --port 4173"{{if .IncludeTesting}},
     "test": "vitest"{{end}}
   },
   "dependencies": {
@@ -20,9 +21,12 @@
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"{{if .IncludeTesting}},
     "vitest": "^1.1.0",

--- a/templates/react-typescript/src/App.css
+++ b/templates/react-typescript/src/App.css
@@ -1,0 +1,17 @@
+:root {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  line-height: 1.5;
+}
+
+.App {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1020;
+  color: #e6edf3;
+}
+
+.App-link {
+  color: #61dafb;
+}
+

--- a/templates/react-typescript/src/main.tsx
+++ b/templates/react-typescript/src/main.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.tsx";
-import "./index.css";
+import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/templates/react-typescript/tsconfig.json
+++ b/templates/react-typescript/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "esnext"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "outDir": "dist",
+    "types": ["vite/client", "vitest"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "src/tests/**"]
+}
+
+

--- a/templates/react-typescript/vite.config.ts
+++ b/templates/react-typescript/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  },
   server: {
     port: 5173,
     open: true

--- a/templates/redis-cache/Dockerfile
+++ b/templates/redis-cache/Dockerfile
@@ -3,12 +3,12 @@ FROM redis:alpine
 # Copy Redis configuration
 COPY redis.conf /usr/local/etc/redis/redis.conf
 
-# Expose port
-EXPOSE {{.Port}}
+# Expose default Redis port (informational)
+EXPOSE "{{.Port}}"
 
-# Health check
+# Health check (password-aware for local/dev)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD redis-cli ping || exit 1
+    CMD {{if .Password}}redis-cli -a "{{.Password}}" ping{{else}}redis-cli ping{{end}} || exit 1
 
 # Start Redis with custom config
 CMD ["redis-server", "/usr/local/etc/redis/redis.conf"] 

--- a/templates/redis-cache/redis.conf
+++ b/templates/redis-cache/redis.conf
@@ -18,9 +18,9 @@ save 900 1
 save 300 10
 save 60 10000
 
-# Logging
+# Logging to stdout/stderr for containers
 loglevel notice
-logfile /var/log/redis/redis.log
+logfile ""
 
 # Performance
 tcp-keepalive 300

--- a/templates/vue-nuxt/Dockerfile
+++ b/templates/vue-nuxt/Dockerfile
@@ -1,23 +1,16 @@
 # Use Node.js 18 Alpine as base image
 FROM node:18-alpine
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
+RUN sh -lc 'if [ -f package-lock.json ]; then npm ci; else npm install; fi'
 
-# Install dependencies
-RUN npm ci
-
-# Copy application code
 COPY . .
 
-# Build the application
 RUN npm run build
 
-# Expose port
 EXPOSE 3000
 
-# Start the application
-CMD ["npm", "start"] 
+# Local/dev-friendly Nuxt 3 preview server
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "3000"]

--- a/templates/vue-nuxt/tsconfig.json
+++ b/templates/vue-nuxt/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "skipLibCheck": true,
+    "types": ["node", "vue", "vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.vue"],
+  "exclude": ["node_modules", ".nuxt", "dist"]
+}
+
+


### PR DESCRIPTION
…erraform tip

- README:
  - Quickstart: use `om add service --template fastapi-basic` (no positional args)

- docs/architecture.md:
  - Add `om ls --detailed` flag
  - Update `om delete` to subcommands: service|component|resource with `--files`
  - Mark Terraform generator as temporarily disabled
  - Standardize parameter type to `multiselect`

- docs/CREATING_A_TEMPLATE.md:
  - Standardize parameter type: `multi-select` -> `multiselect`
  - Align manifest schema to `apiVersion: openworkbench.io/v1alpha1`, `kind: Project`
  - Normalize example paths to `./frontend`, `./backend`, `./gateway`

- cmd/ls.go:
  - Remove/gate Terraform tip in summary output

- cmd/add_service.go:
  - Fix component example to use `--template nginx-gateway`
  - Expand template list to include `nginx-gateway`, `redis-cache`

No linter issues in modified Go files.